### PR TITLE
Add run-skill-audit skill

### DIFF
--- a/dot_claude/skills/run-skill-audit/SKILL.md
+++ b/dot_claude/skills/run-skill-audit/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: run-skill-audit
+description: >-
+  スキルポートフォリオの健全性を監査する。セッションログからルーティング精度・誤発火・競合を分析し、
+  HTMLレポートと改善パッチを生成する。「スキル監査」「skill audit」「スキルの精度を分析」
+  「誤発火を調べたい」「スキルルーティング分析」「スキルの健全性チェック」
+  「ルーティング精度」「スキルが正しく発火しているか確認」などのリクエストに対応する。
+  スキルのdescriptionを最適化したいだけならskill-creatorを使うこと。
+  このスキルはポートフォリオ全体を実セッションデータで検証するもの。
+---
+
+# Run Skill Audit
+
+skill-auditor のワークフローを一括実行するオーケストレーションスキル。
+データ収集からHTMLレポート生成・パッチ適用まで、すべてのステップを自動化する。
+
+このスキルは `scripts/` 配下のヘルパースクリプトと、
+skill-auditor 本体（`~/.claude/skills/skill-auditor/`）のスクリプト・エージェント定義を
+組み合わせて動作する。
+
+## 前提
+
+- `~/.claude/skills/skill-auditor/` がインストール済みであること
+- 未インストールの場合は自動インストール:
+  ```bash
+  git clone --depth 1 https://github.com/nyosegawa/skills.git /tmp/nyosegawa-skills
+  cp -r /tmp/nyosegawa-skills/skills/skill-auditor ~/.claude/skills/skill-auditor
+  ```
+
+## パス定義
+
+スキル内で使う変数名:
+- `SKILL_AUDITOR_DIR`: `~/.claude/skills/skill-auditor`
+- `RUN_SKILL_AUDIT_DIR`: このスキルのディレクトリ（`~/.claude/skills/run-skill-audit`）
+- `BASE_DIR`: レポートのベースディレクトリ
+  - current-project mode: `<project_root>/.claude/skill-report/`
+  - cross-project mode: `~/.claude/skill-report/`
+- `WORKSPACE`: `${BASE_DIR}/<RUN_ID>`（タイムスタンプ付き）
+
+## ワークフロー
+
+### Step 0: 確認
+
+ユーザーに2点だけ確認（デフォルト値を提示して即決できるように）:
+1. **言語**: デフォルトは会話言語と同じ（日本語なら日本語）
+2. **スコープ**: デフォルトは「現在のプロジェクトのみ」
+
+### Step 1: ワークスペース作成 & データ収集
+
+```bash
+RUN_ID=$(date +%Y-%m-%dT%H-%M-%S)
+WORKSPACE=${BASE_DIR}/${RUN_ID}
+mkdir -p ${WORKSPACE}
+
+# current-project mode
+python3 ${SKILL_AUDITOR_DIR}/scripts/collect_transcripts.py \
+  --cwd "$(pwd)" --days 14 \
+  --output ${WORKSPACE}/transcripts.json --verbose
+
+# cross-project mode（スコープが全プロジェクトの場合）
+# python3 ${SKILL_AUDITOR_DIR}/scripts/collect_transcripts.py all --days 14 \
+#   --output ${WORKSPACE}/transcripts.json --verbose
+
+python3 ${SKILL_AUDITOR_DIR}/scripts/collect_skills.py \
+  --output ${WORKSPACE}/skill-manifest.json --verbose
+```
+
+収集サマリーをユーザーに報告: "N sessions, M turns, K skills"
+
+### Step 2: バッチ構成
+
+専用スクリプトでバッチを構成する。プロジェクト固有のローカルスキルを持つセッションは
+別バッチに分離され、グローバルスキルのみのセッションはプールされる。
+
+```bash
+python3 ${RUN_SKILL_AUDIT_DIR}/scripts/build_batches.py \
+  --workspace ${WORKSPACE}
+```
+
+出力: `${WORKSPACE}/batches.json`
+
+### Step 3: ルーティング監査（並列サブエージェント）
+
+`batches.json` を読み、バッチ数だけサブエージェントを `run_in_background: true` で並列起動。
+
+各サブエージェントへの指示:
+```
+Read ${SKILL_AUDITOR_DIR}/agents/routing-analyst.md for your analysis instructions.
+Read ${WORKSPACE}/skill-manifest.json for skill definitions.
+Read ${WORKSPACE}/transcripts.json for session data.
+Only analyze sessions with these indices: [batch.session_indices]
+Only evaluate against these skills: [batch.visible_skill_names]
+These skills have disable-model-invocation and NEVER auto-fire: [batch.dmi_skill_names]
+Write ALL output text in [言語].
+Write your analysis as JSON to /tmp/batch-audit-{i}.json
+following the exact schema in ${SKILL_AUDITOR_DIR}/schemas/schemas.md (audit-report.json section).
+```
+
+**ファイル書き込みの注意**: main ブランチ保護 hook がある環境では、
+サブエージェントに `/tmp/` へ書かせてから `cp` でワークスペースにコピーする。
+
+全バッチ完了後:
+```bash
+cp /tmp/batch-audit-*.json ${WORKSPACE}/
+```
+
+### Step 4: 結果マージ
+
+専用スクリプトでマージ。サブエージェント間のフィールド名の揺れ
+（`total_fires` vs `fire_count` 等）を自動正規化する。
+
+```bash
+python3 ${RUN_SKILL_AUDIT_DIR}/scripts/merge_batches.py \
+  --workspace ${WORKSPACE}
+```
+
+出力: `${WORKSPACE}/audit-report.json`
+
+### Step 5: ポートフォリオ分析 & 改善提案（並列サブエージェント）
+
+2つのサブエージェントを `run_in_background: true` で並列起動:
+
+**portfolio-analyst:**
+```
+Read ${SKILL_AUDITOR_DIR}/agents/portfolio-analyst.md for instructions.
+Read ${WORKSPACE}/skill-manifest.json for skill definitions and attention budget.
+Read ${WORKSPACE}/audit-report.json for the routing audit results.
+Write ALL output text in [言語].
+Write to /tmp/portfolio-analysis.json, then:
+cp /tmp/portfolio-analysis.json ${WORKSPACE}/portfolio-analysis.json
+```
+
+**improvement-planner:**
+```
+Read ${SKILL_AUDITOR_DIR}/agents/improvement-planner.md for instructions.
+Read ${WORKSPACE}/audit-report.json for routing audit results.
+Read ${WORKSPACE}/portfolio-analysis.json for portfolio analysis.
+Read ${WORKSPACE}/skill-manifest.json for current skill definitions.
+Write ALL output text in [言語].
+Write to /tmp/improvement-proposals.json, then:
+cp /tmp/improvement-proposals.json ${WORKSPACE}/improvement-proposals.json
+mkdir -p ${WORKSPACE}/patches
+cp /tmp/patches/*.patch.json ${WORKSPACE}/patches/
+```
+
+### Step 6: HTMLレポート生成 & 表示
+
+```bash
+python3 ${SKILL_AUDITOR_DIR}/scripts/generate_report.py \
+  --workspace ${WORKSPACE}
+open ${WORKSPACE}/skill-audit-report.html
+```
+
+### Step 7: Health History 更新
+
+```bash
+python3 ${RUN_SKILL_AUDIT_DIR}/scripts/update_health_history.py \
+  --workspace ${WORKSPACE} --base-dir ${BASE_DIR}
+```
+
+### Step 8: サマリー報告 & パッチ適用
+
+以下をユーザーに報告:
+- 分析セッション数・ターン数
+- ルーティング精度が低いスキル（テーブル形式）
+- 競合ペア・カバレッジギャップ
+- パッチ提案の一覧（優先度・before/after・期待改善率）
+
+パッチの適用を確認し、承認されたら:
+1. worktree を作成（main ブランチ保護がある場合）
+2. パッチの `proposed_description` で各 SKILL.md の description を更新
+3. コミット → push → PR 作成（draft）
+
+## トラブルシューティング
+
+- **"No project found"**: `--cwd` でプロジェクトルートを明示指定
+- **サブエージェントのファイル書き込みがブロックされる**: `/tmp/` 経由で書き込み→cp
+- **マージ後の stats が全て 0**: フィールド名の揺れ。`merge_batches.py` が自動対応するので
+  手動マージせずスクリプトを使うこと
+- **セッション数が少ない**: `--days` を増やす（デフォルト14日）

--- a/dot_claude/skills/run-skill-audit/evals/evals.json
+++ b/dot_claude/skills/run-skill-audit/evals/evals.json
@@ -1,0 +1,35 @@
+{
+  "skill_name": "run-skill-audit",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "スキル監査して",
+      "expected_output": "スキルポートフォリオの監査ワークフローが開始される。言語とスコープの確認後、データ収集→バッチ分析→マージ→ポートフォリオ分析→HTMLレポート生成まで自動実行される",
+      "should_trigger": true
+    },
+    {
+      "id": 2,
+      "prompt": "最近スキルの誤発火が気になるんだけど、build-sourceが変なタイミングで発火する。全体的に調べてほしい",
+      "expected_output": "skill-auditorのワークフローが実行され、build-sourceを含む全スキルのルーティング精度が分析される。誤発火パターンの特定と改善パッチが提案される",
+      "should_trigger": true
+    },
+    {
+      "id": 3,
+      "prompt": "スキルのdescriptionをもっと良くしたい。build-sourceの説明文を最適化して",
+      "expected_output": "これはskill-creatorの領域。run-skill-auditは発火しないべき",
+      "should_trigger": false
+    },
+    {
+      "id": 4,
+      "prompt": "新しいスキルを作りたい。dbtモデルのレビュー用のスキルが欲しい",
+      "expected_output": "これはskill-creatorの領域。run-skill-auditは発火しないべき",
+      "should_trigger": false
+    },
+    {
+      "id": 5,
+      "prompt": "skill auditの結果を見たい。前回のレポートどこにある？",
+      "expected_output": "既存のレポートパスを案内するか、新規監査の実行を提案する",
+      "should_trigger": true
+    }
+  ]
+}

--- a/dot_claude/skills/run-skill-audit/scripts/build_batches.py
+++ b/dot_claude/skills/run-skill-audit/scripts/build_batches.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+build_batches.py — Build routing-audit batches from transcripts and skill manifest.
+
+Groups sessions by their visible skill set (global-only vs project-local),
+then caps total batch count via greedy merging.
+
+Usage:
+    python3 build_batches.py --workspace <path> [--batch-size 60] [--max-batches 12]
+
+Output:
+    <workspace>/batches.json
+"""
+
+import json
+import argparse
+from collections import defaultdict
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build routing-audit batches")
+    parser.add_argument("--workspace", required=True, help="Workspace directory")
+    parser.add_argument("--batch-size", type=int, default=60, help="Max sessions per batch")
+    parser.add_argument("--max-batches", type=int, default=12, help="Max total batches")
+    args = parser.parse_args()
+
+    data = json.load(open(f"{args.workspace}/transcripts.json"))
+    manifest = json.load(open(f"{args.workspace}/skill-manifest.json"))
+    sessions = data["sessions"]
+
+    # Identify global vs project-local skills
+    global_skills = [s for s in manifest["skills"] if s["scope"] == "global"]
+    global_names = [s["name"] for s in global_skills]
+    project_local = defaultdict(list)
+    for s in manifest["skills"]:
+        if s["scope"] == "project-local" and s.get("project_path"):
+            project_local[s["project_path"]].append(s)
+
+    def find_local_skills(project_dir):
+        for pp, skills in project_local.items():
+            encoded = pp.replace("/", "-").replace(".", "-")
+            if encoded.lstrip("-") in project_dir.lstrip("-"):
+                return skills
+        return []
+
+    # Separate sessions by skill visibility
+    global_only_indices = []
+    local_project_groups = defaultdict(list)
+
+    for i, s in enumerate(sessions):
+        pdir = s.get("project_dir", "unknown")
+        locals_ = find_local_skills(pdir)
+        if locals_:
+            local_project_groups[pdir].append(i)
+        else:
+            global_only_indices.append(i)
+
+    # Build batches
+    batches = []
+
+    # 1) Pool global-only sessions
+    for chunk_start in range(0, len(global_only_indices), args.batch_size):
+        chunk = global_only_indices[chunk_start : chunk_start + args.batch_size]
+        batches.append(
+            {
+                "session_indices": chunk,
+                "label": "global-only (mixed projects)",
+                "visible_skill_names": global_names,
+            }
+        )
+
+    # 2) Group projects with same local skill set
+    by_skill_set = defaultdict(list)
+    for pdir, indices in local_project_groups.items():
+        local_names = tuple(sorted(s["name"] for s in find_local_skills(pdir)))
+        by_skill_set[local_names].extend(indices)
+
+    local_batches = []
+    for local_names, indices in by_skill_set.items():
+        visible = global_names + list(local_names)
+        for chunk_start in range(0, len(indices), args.batch_size):
+            chunk = indices[chunk_start : chunk_start + args.batch_size]
+            local_batches.append(
+                {
+                    "session_indices": chunk,
+                    "label": f"local skills: {', '.join(local_names[:3])}{'...' if len(local_names) > 3 else ''}",
+                    "visible_skill_names": visible,
+                    "_local_set": set(local_names),
+                }
+            )
+
+    # 3) Merge if too many batches
+    remaining_budget = args.max_batches - len(batches)
+    while len(local_batches) > remaining_budget and len(local_batches) > 1:
+        smallest_idx = min(
+            range(len(local_batches)),
+            key=lambda i: len(local_batches[i]["session_indices"]),
+        )
+        smallest = local_batches.pop(smallest_idx)
+        best_idx, best_extra = 0, float("inf")
+        for j, b in enumerate(local_batches):
+            extra = len(smallest["_local_set"] - b["_local_set"]) + len(
+                b["_local_set"] - smallest["_local_set"]
+            )
+            if extra < best_extra:
+                best_idx, best_extra = j, extra
+        target = local_batches[best_idx]
+        target["session_indices"].extend(smallest["session_indices"])
+        target["_local_set"] = target["_local_set"] | smallest["_local_set"]
+        merged_local = sorted(target["_local_set"])
+        target["visible_skill_names"] = global_names + merged_local
+        target["label"] = f"merged local skills: {', '.join(merged_local[:3])}{'...' if len(merged_local) > 3 else ''}"
+
+    for b in local_batches:
+        b.pop("_local_set", None)
+        batches.append(b)
+
+    # Add DMI info
+    dmi_skills = {s["name"] for s in manifest["skills"] if s.get("disable_model_invocation")}
+    for b in batches:
+        b["dmi_skill_names"] = sorted(set(b["visible_skill_names"]) & dmi_skills)
+
+    # Write output
+    output_path = f"{args.workspace}/batches.json"
+    with open(output_path, "w") as f:
+        json.dump(batches, f, indent=2, ensure_ascii=False)
+
+    # Print summary
+    total_sessions = sum(len(b["session_indices"]) for b in batches)
+    print(f"Built {len(batches)} batches covering {total_sessions} sessions")
+    for i, b in enumerate(batches):
+        print(
+            f"  Batch {i}: {len(b['session_indices'])} sessions, "
+            f"{len(b['visible_skill_names'])} skills — {b['label']}"
+        )
+    print(f"Output: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/dot_claude/skills/run-skill-audit/scripts/merge_batches.py
+++ b/dot_claude/skills/run-skill-audit/scripts/merge_batches.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+merge_batches.py — Merge batch-audit-*.json files into a single audit-report.json.
+
+Handles field name variants across batches (sub-agents may use slightly
+different names for the same fields). Recalculates accuracy per skill.
+
+Usage:
+    python3 merge_batches.py --workspace <path>
+
+Output:
+    <workspace>/audit-report.json
+"""
+
+import json
+import glob
+import argparse
+
+
+# Field name variants that sub-agents might use
+FIRE_KEYS = ["fire_count", "total_fires", "fires"]
+CORRECT_KEYS = ["correct", "correct_fires", "correct_count"]
+FP_KEYS = ["false_positive", "false_positives", "fp"]
+FN_KEYS = ["false_negative", "false_negatives", "fn"]
+CONFUSED_KEYS = ["confused", "confused_count"]
+EXPLICIT_KEYS = ["explicit_invocation", "explicit_invocations", "explicit"]
+
+
+def get_stat(stats: dict, key_variants: list, default: int = 0) -> int:
+    """Extract a stat value trying multiple possible field names."""
+    for k in key_variants:
+        if k in stats:
+            return stats[k]
+    return default
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Merge batch audit results")
+    parser.add_argument("--workspace", required=True, help="Workspace directory")
+    args = parser.parse_args()
+
+    batch_files = sorted(glob.glob(f"{args.workspace}/batch-audit-*.json"))
+    if not batch_files:
+        print("ERROR: No batch-audit-*.json files found")
+        return 1
+
+    skill_map = {}
+    meta = {
+        "sessions_analyzed": 0,
+        "turns_analyzed": 0,
+        "skill_fires_analyzed": 0,
+        "skills_evaluated": 0,
+        "batch_count": len(batch_files),
+    }
+    all_competition = []
+    all_gaps = []
+
+    for bf in batch_files:
+        try:
+            data = json.load(open(bf))
+        except json.JSONDecodeError as e:
+            print(f"WARNING: Failed to parse {bf}: {e}")
+            continue
+
+        m = data.get("meta", {})
+        meta["sessions_analyzed"] += m.get("sessions_analyzed", 0)
+        meta["turns_analyzed"] += m.get("turns_analyzed", 0)
+        meta["skill_fires_analyzed"] += m.get(
+            "skill_fires_analyzed", m.get("total_skill_fires", 0)
+        )
+
+        # skill_reports can be a list (common) or dict
+        reports = data.get("skill_reports", [])
+        if isinstance(reports, dict):
+            reports = [{"skill_name": k, **v} for k, v in reports.items()]
+
+        for report in reports:
+            name = report.get("skill_name", "")
+            stats = report.get("stats", {})
+            if name not in skill_map:
+                skill_map[name] = {
+                    "skill_name": name,
+                    "skill_path": report.get("skill_path", ""),
+                    "description_excerpt": report.get("description_excerpt", ""),
+                    "stats": {
+                        "total_fires": 0,
+                        "correct_fires": 0,
+                        "false_positives": 0,
+                        "false_negatives": 0,
+                        "accuracy": None,
+                    },
+                    "health_assessment": "",
+                    "incidents": [],
+                }
+            sr = skill_map[name]
+            sr["stats"]["total_fires"] += get_stat(stats, FIRE_KEYS)
+            sr["stats"]["correct_fires"] += get_stat(stats, CORRECT_KEYS)
+            sr["stats"]["false_positives"] += get_stat(stats, FP_KEYS)
+            sr["stats"]["false_negatives"] += get_stat(stats, FN_KEYS)
+            sr["incidents"].extend(report.get("incidents", []))
+            if report.get("health_assessment"):
+                sr["health_assessment"] = report["health_assessment"]
+
+        all_competition.extend(data.get("competition_pairs", []))
+        all_gaps.extend(data.get("coverage_gaps", []))
+
+    # Recalculate accuracy
+    for sr in skill_map.values():
+        s = sr["stats"]
+        total = s["correct_fires"] + s["false_positives"] + s["false_negatives"]
+        s["accuracy"] = round(s["correct_fires"] / total, 3) if total > 0 else None
+
+    # Deduplicate competition pairs
+    seen = set()
+    unique_pairs = []
+    for p in all_competition:
+        key = tuple(sorted([p.get("skill_a", ""), p.get("skill_b", "")]))
+        if key not in seen:
+            seen.add(key)
+            unique_pairs.append(p)
+
+    # Deduplicate coverage gaps
+    seen_gaps = set()
+    unique_gaps = []
+    for g in all_gaps:
+        key = g.get("unmet_intent", "") or g.get("description", "") or str(g)
+        if key not in seen_gaps:
+            seen_gaps.add(key)
+            unique_gaps.append(g)
+
+    meta["skills_evaluated"] = len(skill_map)
+
+    output = {
+        "meta": meta,
+        "skill_reports": list(skill_map.values()),
+        "competition_pairs": unique_pairs,
+        "coverage_gaps": unique_gaps,
+    }
+
+    output_path = f"{args.workspace}/audit-report.json"
+    with open(output_path, "w") as f:
+        json.dump(output, f, indent=2, ensure_ascii=False)
+
+    # Print summary
+    print(f"Merged {len(batch_files)} batches → {output_path}")
+    print(f"Sessions: {meta['sessions_analyzed']}, Turns: {meta['turns_analyzed']}")
+    print(f"Skills: {meta['skills_evaluated']}, Competition pairs: {len(unique_pairs)}")
+    print()
+    for sr in sorted(skill_map.values(), key=lambda x: -x["stats"]["total_fires"]):
+        s = sr["stats"]
+        acc = f"{s['accuracy']:.1%}" if s["accuracy"] is not None else "N/A"
+        print(
+            f"  {sr['skill_name']}: fires={s['total_fires']}, "
+            f"correct={s['correct_fires']}, fp={s['false_positives']}, "
+            f"fn={s['false_negatives']}, accuracy={acc}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/dot_claude/skills/run-skill-audit/scripts/test_scripts.py
+++ b/dot_claude/skills/run-skill-audit/scripts/test_scripts.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""
+Unit tests for run-skill-audit helper scripts.
+
+Tests build_batches.py and merge_batches.py using synthetic data
+to verify correctness without needing real session transcripts.
+
+Usage:
+    python3 test_scripts.py
+"""
+
+import json
+import os
+import sys
+import tempfile
+import subprocess
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def create_test_transcripts(workspace, num_sessions=10):
+    """Create minimal synthetic transcripts.json."""
+    sessions = []
+    for i in range(num_sessions):
+        sessions.append(
+            {
+                "session_id": f"test-session-{i}",
+                "filepath": f"/fake/path/session-{i}.jsonl",
+                "project_dir": "-Users-test-project-a"
+                if i < 7
+                else "-Users-test-project-b",
+                "skills_loaded": [],
+                "user_turn_count": 5,
+                "turn_skill_map": [
+                    {
+                        "turn_index": j,
+                        "user_message": f"test message {j}",
+                        "skills_loaded_after": [],
+                        "is_builtin_command": False,
+                    }
+                    for j in range(5)
+                ],
+            }
+        )
+    data = {
+        "project_path": "test",
+        "sessions": sessions,
+        "summary": {"total_sessions": num_sessions, "total_user_turns": num_sessions * 5},
+    }
+    with open(f"{workspace}/transcripts.json", "w") as f:
+        json.dump(data, f)
+    return data
+
+
+def create_test_manifest(workspace):
+    """Create minimal synthetic skill-manifest.json."""
+    manifest = {
+        "skills": [
+            {
+                "name": "global-skill-a",
+                "scope": "global",
+                "description": "A global skill",
+                "description_tokens": 10,
+                "disable_model_invocation": False,
+            },
+            {
+                "name": "global-skill-b",
+                "scope": "global",
+                "description": "Another global skill",
+                "description_tokens": 12,
+                "disable_model_invocation": True,
+            },
+            {
+                "name": "local-skill-a",
+                "scope": "project-local",
+                "project_path": "/Users/test/project-a",
+                "description": "A local skill",
+                "description_tokens": 8,
+                "disable_model_invocation": False,
+            },
+        ],
+        "summary": {"total_skills": 3},
+        "attention_budget": {"total_description_tokens": 30},
+    }
+    with open(f"{workspace}/skill-manifest.json", "w") as f:
+        json.dump(manifest, f)
+    return manifest
+
+
+def create_test_batch_results(workspace, num_batches=2):
+    """Create synthetic batch-audit files with intentional field name variants."""
+    for i in range(num_batches):
+        # Alternate between field name styles to test normalization
+        if i == 0:
+            stats = {
+                "total_fires": 5,
+                "correct_fires": 3,
+                "false_positives": 2,
+                "false_negatives": 0,
+                "accuracy": 0.6,
+            }
+        else:
+            stats = {
+                "fire_count": 3,
+                "correct": 2,
+                "false_positive": 1,
+                "false_negative": 0,
+                "accuracy": 0.667,
+            }
+
+        data = {
+            "skill_reports": [
+                {
+                    "skill_name": "test-skill",
+                    "skill_path": "/fake/path",
+                    "description_excerpt": "test",
+                    "stats": stats,
+                    "incidents": [],
+                    "health_assessment": f"batch {i} assessment",
+                }
+            ],
+            "competition_pairs": [],
+            "coverage_gaps": [],
+            "meta": {
+                "sessions_analyzed": 5,
+                "turns_analyzed": 25,
+                "skill_fires_analyzed": stats.get("total_fires", stats.get("fire_count", 0)),
+            },
+        }
+        with open(f"{workspace}/batch-audit-{i}.json", "w") as f:
+            json.dump(data, f)
+
+
+def test_build_batches():
+    """Test that build_batches.py produces valid batches."""
+    print("Test: build_batches.py")
+    with tempfile.TemporaryDirectory() as workspace:
+        create_test_transcripts(workspace, num_sessions=10)
+        create_test_manifest(workspace)
+
+        result = subprocess.run(
+            [sys.executable, f"{SCRIPT_DIR}/build_batches.py", "--workspace", workspace],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"build_batches failed: {result.stderr}"
+
+        batches = json.load(open(f"{workspace}/batches.json"))
+        assert isinstance(batches, list), "batches should be a list"
+        assert len(batches) > 0, "should have at least 1 batch"
+
+        # Check structure
+        for b in batches:
+            assert "session_indices" in b, "batch missing session_indices"
+            assert "visible_skill_names" in b, "batch missing visible_skill_names"
+            assert "dmi_skill_names" in b, "batch missing dmi_skill_names"
+            assert len(b["session_indices"]) > 0, "batch has no sessions"
+
+        # Check DMI skills detected
+        all_dmi = set()
+        for b in batches:
+            all_dmi.update(b["dmi_skill_names"])
+        assert "global-skill-b" in all_dmi, "should detect DMI skill"
+
+        # Check all sessions are covered
+        all_indices = []
+        for b in batches:
+            all_indices.extend(b["session_indices"])
+        assert sorted(all_indices) == list(range(10)), "all 10 sessions should be in batches"
+
+        print("  PASS: batches.json structure is valid")
+        print(f"  PASS: {len(batches)} batches, {len(all_indices)} sessions covered")
+        print(f"  PASS: DMI skills detected: {all_dmi}")
+
+
+def test_merge_batches():
+    """Test that merge_batches.py handles field name variants correctly."""
+    print("Test: merge_batches.py")
+    with tempfile.TemporaryDirectory() as workspace:
+        create_test_batch_results(workspace, num_batches=2)
+
+        result = subprocess.run(
+            [sys.executable, f"{SCRIPT_DIR}/merge_batches.py", "--workspace", workspace],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"merge_batches failed: {result.stderr}"
+
+        report = json.load(open(f"{workspace}/audit-report.json"))
+
+        # Check structure
+        assert "meta" in report
+        assert "skill_reports" in report
+        assert isinstance(report["skill_reports"], list)
+
+        # Check meta totals
+        meta = report["meta"]
+        assert meta["sessions_analyzed"] == 10, f"expected 10 sessions, got {meta['sessions_analyzed']}"
+        assert meta["turns_analyzed"] == 50, f"expected 50 turns, got {meta['turns_analyzed']}"
+
+        # Check skill stats merged correctly despite field name variants
+        skill = report["skill_reports"][0]
+        stats = skill["stats"]
+        assert stats["total_fires"] == 8, f"expected 8 fires (5+3), got {stats['total_fires']}"
+        assert stats["correct_fires"] == 5, f"expected 5 correct (3+2), got {stats['correct_fires']}"
+        assert stats["false_positives"] == 3, f"expected 3 FP (2+1), got {stats['false_positives']}"
+
+        # Check accuracy recalculated
+        expected_acc = round(5 / (5 + 3 + 0), 3)
+        assert stats["accuracy"] == expected_acc, f"expected accuracy {expected_acc}, got {stats['accuracy']}"
+
+        print("  PASS: field name normalization works (total_fires/fire_count)")
+        print(f"  PASS: merged stats correct: fires={stats['total_fires']}, correct={stats['correct_fires']}, fp={stats['false_positives']}")
+        print(f"  PASS: accuracy recalculated: {stats['accuracy']}")
+
+
+def test_update_health_history():
+    """Test health history append logic."""
+    print("Test: update_health_history.py")
+    with tempfile.TemporaryDirectory() as workspace:
+        base_dir = workspace
+
+        # Create minimal audit-report.json
+        audit = {
+            "meta": {"sessions_analyzed": 100, "turns_analyzed": 500, "skills_evaluated": 10},
+            "competition_pairs": [{"skill_a": "a", "skill_b": "b"}],
+            "coverage_gaps": [],
+        }
+        with open(f"{workspace}/audit-report.json", "w") as f:
+            json.dump(audit, f)
+
+        # Create minimal portfolio-analysis.json
+        portfolio = {
+            "portfolio_health": {
+                "overall_score": "needs_attention",
+                "routing_accuracy_avg": 0.75,
+            },
+            "attention_budget": {"total_tokens": 500},
+        }
+        with open(f"{workspace}/portfolio-analysis.json", "w") as f:
+            json.dump(portfolio, f)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                f"{SCRIPT_DIR}/update_health_history.py",
+                "--workspace",
+                workspace,
+                "--base-dir",
+                base_dir,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"update_health_history failed: {result.stderr}"
+
+        history = json.load(open(f"{base_dir}/health-history.json"))
+        assert len(history) == 1, "should have 1 entry"
+        entry = history[0]
+        assert entry["sessions_analyzed"] == 100
+        assert entry["routing_accuracy_avg"] == 0.75
+        assert entry["portfolio_health"] == "needs_attention"
+        assert entry["competition_conflicts"] == 1
+        assert "timestamp" in entry
+
+        # Run again to test delta display
+        result2 = subprocess.run(
+            [
+                sys.executable,
+                f"{SCRIPT_DIR}/update_health_history.py",
+                "--workspace",
+                workspace,
+                "--base-dir",
+                base_dir,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result2.returncode == 0
+        history2 = json.load(open(f"{base_dir}/health-history.json"))
+        assert len(history2) == 2, "should have 2 entries after second run"
+        assert "前回" in result2.stdout, "should show delta comparison"
+
+        print("  PASS: health history created and appended correctly")
+        print("  PASS: delta comparison works on second run")
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("run-skill-audit script tests")
+    print("=" * 60)
+    print()
+
+    passed = 0
+    failed = 0
+
+    for test_fn in [test_build_batches, test_merge_batches, test_update_health_history]:
+        try:
+            test_fn()
+            passed += 1
+            print()
+        except Exception as e:
+            failed += 1
+            print(f"  FAIL: {e}")
+            print()
+
+    print("=" * 60)
+    print(f"Results: {passed} passed, {failed} failed")
+    print("=" * 60)
+    sys.exit(1 if failed > 0 else 0)

--- a/dot_claude/skills/run-skill-audit/scripts/update_health_history.py
+++ b/dot_claude/skills/run-skill-audit/scripts/update_health_history.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+update_health_history.py — Append current run summary to health-history.json.
+
+Reads audit-report.json and portfolio-analysis.json from the workspace,
+creates a summary entry, and appends to the shared health-history.json.
+Shows delta from previous run if available.
+
+Usage:
+    python3 update_health_history.py --workspace <path> --base-dir <path>
+
+Output:
+    <base_dir>/health-history.json (append)
+"""
+
+import json
+import os
+import argparse
+from datetime import datetime
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Update health history")
+    parser.add_argument("--workspace", required=True)
+    parser.add_argument("--base-dir", required=True)
+    args = parser.parse_args()
+
+    history_file = f"{args.base_dir}/health-history.json"
+
+    # Load existing history
+    if os.path.exists(history_file):
+        history = json.load(open(history_file))
+    else:
+        history = []
+
+    # Read current run data
+    audit = json.load(open(f"{args.workspace}/audit-report.json"))
+    meta = audit.get("meta", {})
+
+    # Try to read portfolio analysis for health score
+    portfolio_file = f"{args.workspace}/portfolio-analysis.json"
+    portfolio_health = "unknown"
+    routing_accuracy_avg = 0.0
+    token_total = 0
+
+    if os.path.exists(portfolio_file):
+        portfolio = json.load(open(portfolio_file))
+        ph = portfolio.get("portfolio_health", {})
+        portfolio_health = ph.get("overall_score", "unknown")
+        routing_accuracy_avg = ph.get("routing_accuracy_avg", 0.0)
+        ab = portfolio.get("attention_budget", {})
+        token_total = ab.get("total_tokens", 0)
+
+    # Count patches if improvement-proposals.json exists
+    proposals_file = f"{args.workspace}/improvement-proposals.json"
+    patches_proposed = 0
+    if os.path.exists(proposals_file):
+        proposals = json.load(open(proposals_file))
+        patches_proposed = len(proposals.get("patches", []))
+
+    entry = {
+        "timestamp": datetime.now().isoformat(),
+        "sessions_analyzed": meta.get("sessions_analyzed", 0),
+        "turns_analyzed": meta.get("turns_analyzed", 0),
+        "portfolio_health": portfolio_health,
+        "routing_accuracy_avg": routing_accuracy_avg,
+        "total_description_tokens": token_total,
+        "competition_conflicts": len(audit.get("competition_pairs", [])),
+        "coverage_gaps": len(audit.get("coverage_gaps", [])),
+        "skills_audited": meta.get("skills_evaluated", 0),
+        "patches_proposed": patches_proposed,
+    }
+
+    # Show delta
+    if history:
+        prev = history[-1]
+        prev_acc = prev.get("routing_accuracy_avg", 0)
+        print(f"前回: {prev_acc:.1%} → 今回: {entry['routing_accuracy_avg']:.1%}")
+        delta = entry["routing_accuracy_avg"] - prev_acc
+        print(f"変化: {delta:+.1%}")
+    else:
+        print("初回実行（比較対象なし）")
+
+    history.append(entry)
+
+    with open(history_file, "w") as f:
+        json.dump(history, f, indent=2, ensure_ascii=False)
+    print(f"Updated: {history_file}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- スキルポートフォリオの健全性を監査する `run-skill-audit` スキルを追加
- セッションログからルーティング精度・誤発火・競合を分析し、HTMLレポートと改善パッチを生成
- ヘルパースクリプト3本（バッチ構成・結果マージ・履歴管理）とユニットテスト付き

## 構成

```
run-skill-audit/
├── SKILL.md                    # オーケストレーション手順
├── evals/evals.json            # 発火テストケース（5件）
└── scripts/
    ├── build_batches.py        # バッチ構成
    ├── merge_batches.py        # 結果マージ（フィールド名揺れ正規化）
    ├── update_health_history.py # 履歴追記・差分表示
    └── test_scripts.py         # ユニットテスト（3/3 PASS）
```

## Test plan

- [x] `python3 scripts/test_scripts.py` — 3/3 PASS
- [ ] `chezmoi apply` で正しくデプロイされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)