### PR TITLE
Add PostToolUse hook to update PR title/body after merge

### DIFF
--- a/dot_claude/hooks/executable_update-pr-on-merge.sh
+++ b/dot_claude/hooks/executable_update-pr-on-merge.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# PostToolUse hook: After a successful PR merge, instruct Claude to update PR title and body
+# to accurately reflect the actual merged changes.
+#
+# Trigger: Bash commands matching `gh api repos/.../pulls/.../merge`
+# Input:   JSON with .tool_input.command and .tool_result.stdout
+
+INPUT=$(cat)
+COMMAND=$(jq -r '.tool_input.command // empty' <<< "$INPUT")
+
+# Only trigger on merge API calls
+if ! grep -qE 'gh api repos/[^/]+/[^/]+/pulls/[0-9]+/merge' <<< "$COMMAND"; then
+  exit 0
+fi
+
+# Check if merge succeeded (successful merge response contains "sha")
+STDOUT=$(jq -r '.tool_result.stdout // empty' <<< "$INPUT")
+if ! jq -e '.sha' <<< "$STDOUT" >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Extract repo and PR number from command
+REPO=$(grep -oE 'repos/[^/]+/[^/]+' <<< "$COMMAND" | head -1 | sed 's/^repos\///')
+PR_NUMBER=$(grep -oE 'pulls/[0-9]+' <<< "$COMMAND" | head -1 | sed 's/^pulls\///')
+
+if [[ -z "$REPO" || -z "$PR_NUMBER" ]]; then
+  exit 0
+fi
+
+# Gather context for Claude: commits and files changed
+COMMITS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/commits" \
+  --jq '.[] | "- " + (.commit.message | split("\n")[0])' 2>/dev/null)
+FILES=$(gh api "repos/$REPO/pulls/$PR_NUMBER/files" \
+  --jq '.[] | "- " + .filename + " (" + .status + ", +" + (.additions|tostring) + " -" + (.changes - .additions | tostring) + ")"' 2>/dev/null)
+CURRENT=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json title,body \
+  --jq '"Current title: " + .title + "\nCurrent body:\n" + .body' 2>/dev/null)
+
+cat <<EOF
+PR #$PR_NUMBER ($REPO) was successfully merged.
+
+Please update the PR title and body to accurately reflect what was actually merged.
+
+$CURRENT
+
+Commits merged:
+$COMMITS
+
+Files changed:
+$FILES
+
+Instructions:
+1. Review the commits and files above
+2. Update the PR title to concisely describe the actual changes (keep under 70 chars)
+3. Update the PR body with a clear summary of what was merged
+4. Use: gh pr edit $PR_NUMBER --repo $REPO --title "..." --body "..."
+EOF

--- a/dot_claude/hooks/test_update-pr-on-merge.sh
+++ b/dot_claude/hooks/test_update-pr-on-merge.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Test script for update-pr-on-merge.sh hook
+# Tests pattern matching and exit behavior without actual GitHub API calls
+
+HOOK="$(dirname "$0")/executable_update-pr-on-merge.sh"
+PASS=0
+FAIL=0
+
+assert_exit() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$actual" -eq "$expected" ]]; then
+    echo "PASS: $desc (exit=$actual)"
+    ((PASS++))
+  else
+    echo "FAIL: $desc (expected exit=$expected, got exit=$actual)"
+    ((FAIL++))
+  fi
+}
+
+assert_output_contains() {
+  local desc="$1" pattern="$2" output="$3"
+  if grep -q "$pattern" <<< "$output"; then
+    echo "PASS: $desc (output contains '$pattern')"
+    ((PASS++))
+  else
+    echo "FAIL: $desc (output missing '$pattern')"
+    ((FAIL++))
+  fi
+}
+
+# --- Test 1: Non-merge command should exit 0 silently ---
+OUTPUT=$(echo '{"tool_input":{"command":"gh pr view 123"},"tool_result":{"stdout":""}}' | bash "$HOOK" 2>&1)
+assert_exit "Non-merge command exits silently" 0 $?
+if [[ -z "$OUTPUT" ]]; then
+  echo "PASS: Non-merge command produces no output"
+  ((PASS++))
+else
+  echo "FAIL: Non-merge command should produce no output, got: $OUTPUT"
+  ((FAIL++))
+fi
+
+# --- Test 2: Merge command with failed response (no sha) should exit 0 silently ---
+OUTPUT=$(echo '{"tool_input":{"command":"gh api repos/owner/repo/pulls/42/merge -X PUT -f merge_method=merge"},"tool_result":{"stdout":"{\"message\":\"Pull Request is not mergeable\"}"}}' | bash "$HOOK" 2>&1)
+assert_exit "Failed merge exits silently" 0 $?
+if [[ -z "$OUTPUT" ]]; then
+  echo "PASS: Failed merge produces no output"
+  ((PASS++))
+else
+  echo "FAIL: Failed merge should produce no output, got: $OUTPUT"
+  ((FAIL++))
+fi
+
+# --- Test 3: Merge command pattern detection variants ---
+for CMD in \
+  "gh api repos/owner/repo/pulls/123/merge -X PUT -f merge_method=merge" \
+  "gh api repos/my-org/my-repo/pulls/9999/merge -X PUT" \
+  "gh api repos/foo/bar/pulls/1/merge"; do
+
+  # These should match the pattern but fail on sha check (no sha in response)
+  OUTPUT=$(echo "{\"tool_input\":{\"command\":\"$CMD\"},\"tool_result\":{\"stdout\":\"{}\"}}" | bash "$HOOK" 2>&1)
+  assert_exit "Pattern matches: $CMD" 0 $?
+  if [[ -z "$OUTPUT" ]]; then
+    echo "PASS: No sha → no output for: $CMD"
+    ((PASS++))
+  else
+    echo "FAIL: Should produce no output without sha: $CMD"
+    ((FAIL++))
+  fi
+done
+
+# --- Test 4: Non-matching patterns should be ignored ---
+for CMD in \
+  "gh api repos/owner/repo/pulls/123" \
+  "gh pr merge 123" \
+  "echo hello" \
+  "gh api repos/owner/repo/issues/123/merge"; do
+
+  OUTPUT=$(echo "{\"tool_input\":{\"command\":\"$CMD\"},\"tool_result\":{\"stdout\":\"\"}}" | bash "$HOOK" 2>&1)
+  assert_exit "Non-matching: $CMD" 0 $?
+  if [[ -z "$OUTPUT" ]]; then
+    echo "PASS: Correctly ignored: $CMD"
+    ((PASS++))
+  else
+    echo "FAIL: Should be ignored: $CMD, got: $OUTPUT"
+    ((FAIL++))
+  fi
+done
+
+# --- Test 5: Successful merge triggers output (will fail on gh api calls, but tests the flow) ---
+# We test that the pattern + sha detection works, even though gh api calls will fail
+MERGE_RESPONSE='{"sha":"abc123def456","merged":true,"message":"Pull Request successfully merged"}'
+OUTPUT=$(echo "{\"tool_input\":{\"command\":\"gh api repos/test-owner/test-repo/pulls/42/merge -X PUT -f merge_method=merge\"},\"tool_result\":{\"stdout\":$MERGE_RESPONSE}}" | bash "$HOOK" 2>&1)
+assert_exit "Successful merge triggers hook" 0 $?
+assert_output_contains "Output mentions PR number" "#42" "$OUTPUT"
+assert_output_contains "Output mentions repo" "test-owner/test-repo" "$OUTPUT"
+assert_output_contains "Output has update instructions" "gh pr edit" "$OUTPUT"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1

--- a/dot_claude/settings.json
+++ b/dot_claude/settings.json
@@ -78,6 +78,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/update-pr-on-merge.sh",
+            "timeout": 30
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Summary

- PRマージ成功時に自動発火するPostToolUseフックを追加
- マージされたコミット一覧・変更ファイルを収集し、Claudeにtitle/bodyの更新を指示
- `gh api repos/.../pulls/.../merge` パターンを検出、sha有無で成功判定

## Test plan

- [x] 非マージコマンドは無視される（exit 0、出力なし）
- [x] マージ失敗（sha なし）は無視される
- [x] 各種マージコマンドパターンを正しく検出
- [x] 非マッチパターン（issues、gh pr merge等）は無視
- [x] 成功時にPR番号・repo・更新指示を出力
- 22テスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)