### PR TITLE
zoxide の z にフォールバックを追加

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -49,7 +49,22 @@ eval "$(direnv hook zsh)"
 
 # zoxide
 export _ZO_DOCTOR=0
-command -v zoxide &>/dev/null && eval "$(zoxide init zsh)"
+if command -v zoxide &>/dev/null; then
+  eval "$(zoxide init zsh)"
+  # z: 実パスなら cd、zoxide でヒットしなければ zi にフォールバック
+  unalias z 2>/dev/null
+  z() {
+    if [[ $# -eq 0 ]]; then
+      __zoxide_z
+      return
+    fi
+    if [[ -d "$*" ]]; then
+      builtin cd -- "$*"
+      return
+    fi
+    __zoxide_z "$@" 2>/dev/null || __zoxide_zi "$@"
+  }
+fi
 
 # sheldon plugin manager
 eval "$(sheldon source)"


### PR DESCRIPTION
## Summary
- \`z <path>\` で実ディレクトリなら素直に \`cd\` する
- zoxide でヒットしなかった場合は \`zi\`（fzf 対話選択）にフォールバック
- \`zoxide: no match found\` で手が止まって打ち直す頻度を減らす狙い

## Test plan
- [x] \`zsh -n\` で構文チェック
- [x] \`z /tmp\` で cd できることを確認
- [ ] シェル再読込後、ヒットしない文字列で \`zi\` が起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)